### PR TITLE
Remove duplicate function definition

### DIFF
--- a/step-05/js/main.js
+++ b/step-05/js/main.js
@@ -174,12 +174,6 @@ function handleIceCandidate(event) {
   }
 }
 
-function handleRemoteStreamAdded(event) {
-  console.log('Remote stream added.');
-  remoteVideo.src = window.URL.createObjectURL(event.stream);
-  remoteStream = event.stream;
-}
-
 function handleCreateOfferError(event) {
   console.log('createOffer() error: ', event);
 }


### PR DESCRIPTION
Before this patch, `handleRemoteStreamAdded` was defined twice.

This patch fixes #3.