### PR TITLE
step-05: Fix syntax error pcConfig.iceServer.urls

### DIFF
--- a/step-05/js/main.js
+++ b/step-05/js/main.js
@@ -210,7 +210,7 @@ function onCreateSessionDescriptionError(error) {
 function requestTurn(turnURL) {
   var turnExists = false;
   for (var i in pcConfig.iceServers) {
-    if (pcConfig.iceServers[i].url.substr(0, 5) === 'turn:') {
+    if (pcConfig.iceServers[i].urls.substr(0, 5) === 'turn:') {
       turnExists = true;
       turnReady = true;
       break;
@@ -225,7 +225,7 @@ function requestTurn(turnURL) {
         var turnServer = JSON.parse(xhr.responseText);
         console.log('Got TURN server: ', turnServer);
         pcConfig.iceServers.push({
-          'url': 'turn:' + turnServer.username + '@' + turnServer.turn,
+          'urls': 'turn:' + turnServer.username + '@' + turnServer.turn,
           'credential': turnServer.password
         });
         turnReady = true;


### PR DESCRIPTION
Line 213 expects "url" instead of "urls":

    if (pcConfig.iceServers[i].url.substr(0, 5) === 'turn:') {

This is confirmed in line 227 where another entry is created with "url":

    pcConfig.iceServers.push({
        'url': 'turn:' + turnServer.username + '@' + turnServer.turn,
       // ...
    })