### PR TITLE
[fix]:node-static -> mime.lookup is not a function

### DIFF
--- a/step-05/package.json
+++ b/step-05/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.1",
   "description": "WebRTC codelab",
   "dependencies": {
-    "node-static": "0.7.7",
+    "node-static": "0.7.10",
     "socket.io": "1.2.0"
   }}


### PR DESCRIPTION
```node
/Users/superuser/Downloads/webrtc-web-master/step-04/node_modules/node-static/lib/node-static.js:348
                      mime.lookup(files[0]) ||
                           ^

TypeError: mime.lookup is not a function
    at Server.respond (/Users/superuser/Downloads/webrtc-web-master/step-04/node_modules/node-static/lib/node-static.js:348:28)
    at /Users/superuser/Downloads/webrtc-web-master/step-04/node_modules/node-static/lib/node-static.js:64:22
    at FSReqWrap.oncomplete (fs.js:154:5)
```