### PR TITLE
Add sdp params to step-5&6 to improve compatibility

### DIFF
--- a/step-05/js/main.js
+++ b/step-05/js/main.js
@@ -79,8 +79,9 @@ socket.on('message', function(message) {
     pc.setRemoteDescription(new RTCSessionDescription(message));
   } else if (message.type === 'candidate' && isStarted) {
     var candidate = new RTCIceCandidate({
+      candidate: message.candidate,
+      sdpMid: message.id,
       sdpMLineIndex: message.label,
-      candidate: message.candidate
     });
     pc.addIceCandidate(candidate);
   } else if (message === 'bye' && isStarted) {

--- a/step-06/js/main.js
+++ b/step-06/js/main.js
@@ -160,7 +160,9 @@ function signalingMessageCallback(message) {
 
   } else if (message.type === 'candidate') {
     peerConn.addIceCandidate(new RTCIceCandidate({
-      candidate: message.candidate
+      candidate: message.candidate,
+      sdpMid: message.id,
+      sdpMLineIndex: message.label,
     }));
 
   } else if (message === 'bye') {


### PR DESCRIPTION
I've implemented @nitobuendia 's suggestions on #33.

I don't know the purpose of the 2 extra fields but it seems they are only needed when there is more than one Ice candidate - which seems to be more frequent on firefox than chrome when testing locally