### PR TITLE
Fixes step06 according to latest specs: sdpParams in RTCIceCandidate constructor and use promises

### DIFF
--- a/step-06/js/main.js
+++ b/step-06/js/main.js
@@ -186,9 +186,11 @@ function signalingMessageCallback(message) {
 
   } else if (message.type === 'candidate') {
     peerConn.addIceCandidate(new RTCIceCandidate({
-      candidate: message.candidate
+      candidate: message.candidate,
+      sdpMLineIndex: message.label,
+      sdpMid: message.id
     }));
-
+    
   }
 }
 

--- a/step-06/js/main.js
+++ b/step-06/js/main.js
@@ -220,7 +220,15 @@ if (isInitiator) {
   onDataChannelCreated(dataChannel);
 
   console.log('Creating an offer');
-  peerConn.createOffer(onLocalSessionCreated, logError);
+  peerConn.createOffer().then(function(offer) {
+    return peerConn.setLocalDescription(offer);
+  })
+  .then(() => {
+    console.log('sending local desc:', peerConn.localDescription);
+    sendMessage(peerConn.localDescription);
+  })
+  .catch(logError);
+
 } else {
   peerConn.ondatachannel = function(event) {
     console.log('ondatachannel:', event.channel);
@@ -232,10 +240,10 @@ if (isInitiator) {
 
 function onLocalSessionCreated(desc) {
   console.log('local session created:', desc);
-  peerConn.setLocalDescription(desc, function() {
+  peerConn.setLocalDescription(desc).then(function() {
     console.log('sending local desc:', peerConn.localDescription);
     sendMessage(peerConn.localDescription);
-  }, logError);
+  }).catch(logError);
 }
 
 function onDataChannelCreated(channel) {


### PR DESCRIPTION
The lack of sdpParams in the RTCIceCandidate constructor was throwing a newly created TypeError as per [the latest spec draft](https://www.w3.org/TR/webrtc/#dom-peerconnection-addicecandidate) and .

Moreover, the usage of callbacks in createOffer was causing a race condition that sometimes led to sending a null offer that caused an error on the other peer.