### PR TITLE
step-05: become Initiaor after remoteHangup

### DIFF
--- a/step-05/js/main.js
+++ b/step-05/js/main.js
@@ -247,7 +247,7 @@ function hangup() {
 function handleRemoteHangup() {
   console.log('Session terminated.');
   stop();
-  isInitiator = false;
+  isInitiator = true;
 }
 
 function stop() {


### PR DESCRIPTION
Reloading a window prevents a reconnect, forcing one to restart both ends.

This commit sets `isInitiator` to true and thereby allowing other peers to reconnect after a reload.